### PR TITLE
Dependency check in setup.py

### DIFF
--- a/carpsd/setup.py
+++ b/carpsd/setup.py
@@ -4,6 +4,30 @@
 # Author: Timothy Stranex <tstranex@carpcomm.com>
 
 from distutils.core import setup
+from distutils.command.build import build
+
+dependencies=['numpy']
+
+# Custom build class that checks for dependencies before building
+class Build(build):
+    def run(self):
+        if not CheckDependencies():
+            print('Unresolved dependencies. Exiting.')
+            quit()
+
+        build.run(self)
+
+def CheckDependencies():
+    noErrors = True
+
+    for d in dependencies:
+        try:
+            __import__(d)
+        except ImportError as ie:
+            print('The module \''+ d + '\' is not installed.')
+            noErrors = False
+
+    return noErrors
 
 setup(name='carpsd',
       version='0.17',
@@ -17,4 +41,5 @@ setup(name='carpsd',
       data_files=[('/etc/init.d', ['etc/init.d/carpsd']),
                   ('/etc/carpsd', ['etc/carpsd.conf']),
                   ('/etc/carpsd', ['etc/ca_cert.pem'])],
+      cmdclass={'build': Build}
       )


### PR DESCRIPTION
The build and install process for carpsd ran smoothly for me. I then tried to run it, but got an error message that numpy could not be imported. I think it would be useful to warn the user during installation that numpy should be installed.

I first tried using the "requires" option in setup.py. This did nothing. I'm also not the only person to have this problem:
http://blog.doughellmann.com/2007/11/requiring-packages-with-distutils.html

So instead this patch is a workaround that uses a custom build module. 
